### PR TITLE
Initial Electron MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+output/

--- a/README.md
+++ b/README.md
@@ -147,3 +147,7 @@ System: You are a senior software engineer.
 User: Based on the selected files below from the Customizer, generate equivalent or updated files for the Product project.
 ```
 
+
+### MVP Quick Start
+Run `npm install` then `npm start` to launch the Electron app.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Code Diff Assistant</title>
+  </head>
+  <body>
+    <h1>Code Diff Assistant MVP</h1>
+    <div>
+      <button id="product-btn">Select Product Folder</button>
+      <span id="product-path"></span>
+    </div>
+    <div>
+      <button id="customizer-btn">Select Customizer Folder</button>
+      <span id="customizer-path"></span>
+    </div>
+    <div>
+      <input id="extensions" placeholder="Extensions e.g. .cs,.js" />
+    </div>
+    <div>
+      <button id="generate">Generate Summary</button>
+    </div>
+    <div id="status"></div>
+    <script src="renderer.js"></script>
+  </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,41 @@
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const path = require('path');
+const { generateSummary } = require('./utils/fileUtils');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+ipcMain.handle('select-folder', async () => {
+  const { canceled, filePaths } = await dialog.showOpenDialog({
+    properties: ['openDirectory']
+  });
+  if (canceled) return null;
+  return filePaths[0];
+});
+
+ipcMain.handle('generate-summary', async (_event, opts) => {
+  const { productDir, customizerDir, extensions, output } = opts;
+  await generateSummary(productDir, customizerDir, extensions, output);
+  return true;
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "code-diff-assistant",
+  "version": "0.1.0",
+  "description": "Electron MVP for code diff parser",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^26.2.2"
+  }
+}

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,6 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  selectFolder: () => ipcRenderer.invoke('select-folder'),
+  generateSummary: (opts) => ipcRenderer.invoke('generate-summary', opts)
+});

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,37 @@
+const productBtn = document.getElementById('product-btn');
+const customizerBtn = document.getElementById('customizer-btn');
+const generateBtn = document.getElementById('generate');
+const productPathSpan = document.getElementById('product-path');
+const customizerPathSpan = document.getElementById('customizer-path');
+const statusDiv = document.getElementById('status');
+
+let productDir = null;
+let customizerDir = null;
+
+productBtn.addEventListener('click', async () => {
+  const result = await window.api.selectFolder();
+  if (result) {
+    productDir = result;
+    productPathSpan.textContent = result;
+  }
+});
+
+customizerBtn.addEventListener('click', async () => {
+  const result = await window.api.selectFolder();
+  if (result) {
+    customizerDir = result;
+    customizerPathSpan.textContent = result;
+  }
+});
+
+generateBtn.addEventListener('click', async () => {
+  if (!productDir || !customizerDir) {
+    statusDiv.textContent = 'Select both folders first.';
+    return;
+  }
+  const extensions = document.getElementById('extensions').value.split(',').map(e => e.trim()).filter(Boolean);
+  const output = 'output/summary.md';
+  statusDiv.textContent = 'Generating...';
+  await window.api.generateSummary({ productDir, customizerDir, extensions, output });
+  statusDiv.textContent = 'Saved to ' + output;
+});

--- a/utils/fileUtils.js
+++ b/utils/fileUtils.js
@@ -1,0 +1,32 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+async function listFiles(dir, extensions, result = []) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await listFiles(fullPath, extensions, result);
+    } else if (extensions.length === 0 || extensions.includes(path.extname(entry.name))) {
+      result.push(fullPath);
+    }
+  }
+  return result;
+}
+
+async function generateSummary(productDir, customizerDir, extensions, output) {
+  const files = await listFiles(customizerDir, extensions);
+  let summary = '';
+  for (const file of files) {
+    const relPath = path.relative(customizerDir, file);
+    const content = await fs.readFile(file, 'utf8');
+    summary += `## File: ${relPath}\n`;
+    summary += '```\n';
+    summary += content;
+    summary += '\n```\n\n';
+  }
+  await fs.mkdir(path.dirname(output), { recursive: true });
+  await fs.writeFile(output, summary);
+}
+
+module.exports = { generateSummary };


### PR DESCRIPTION
## Summary
- add package.json and Electron dependencies
- implement simple `main.js` with folder selection and summary generation
- expose APIs in `preload.js`
- create a basic HTML UI and renderer script
- add utility for reading files and exporting summary
- update README with quick start instructions
- ignore `node_modules` and `output` directories

## Testing
- `npm install --silent` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_685c5dbfeb40832388d95fdc2d4e3867