### PR TITLE
Add summary preview to MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project is a cross-platform desktop application built with Electron, design
 - Select two root folders: one for the base Product codebase, one for the Customizer.
 - Filter and select files by extension (e.g., C#, JavaScript, SQL).
 - Export selected files into a single summary document.
+- View the generated summary directly in the app before saving.
 - Generate a unified input file in Markdown or plain text format.
 - Designed to create LLM-ready prompts for code understanding or code generation tasks.
 
@@ -127,8 +128,8 @@ npm start
 ```
 
 2. Choose Product and Customizer folders.
-3. Click "Generate LLM Input".
-4. Review and export the result.
+3. Click "Generate LLM Input" to produce a preview.
+4. Review the summary in the app and export the result.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,8 @@
     <div>
       <button id="generate">Generate Summary</button>
     </div>
-    <div id="status"></div>
-    <script src="renderer.js"></script>
+  <div id="status"></div>
+  <pre id="summary"></pre>
+  <script src="renderer.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -36,6 +36,6 @@ ipcMain.handle('select-folder', async () => {
 
 ipcMain.handle('generate-summary', async (_event, opts) => {
   const { productDir, customizerDir, extensions, output } = opts;
-  await generateSummary(productDir, customizerDir, extensions, output);
-  return true;
+  const summary = await generateSummary(productDir, customizerDir, extensions, output);
+  return summary;
 });

--- a/renderer.js
+++ b/renderer.js
@@ -4,6 +4,7 @@ const generateBtn = document.getElementById('generate');
 const productPathSpan = document.getElementById('product-path');
 const customizerPathSpan = document.getElementById('customizer-path');
 const statusDiv = document.getElementById('status');
+const summaryPre = document.getElementById('summary');
 
 let productDir = null;
 let customizerDir = null;
@@ -32,6 +33,7 @@ generateBtn.addEventListener('click', async () => {
   const extensions = document.getElementById('extensions').value.split(',').map(e => e.trim()).filter(Boolean);
   const output = 'output/summary.md';
   statusDiv.textContent = 'Generating...';
-  await window.api.generateSummary({ productDir, customizerDir, extensions, output });
+  const summary = await window.api.generateSummary({ productDir, customizerDir, extensions, output });
   statusDiv.textContent = 'Saved to ' + output;
+  summaryPre.textContent = summary;
 });

--- a/utils/fileUtils.js
+++ b/utils/fileUtils.js
@@ -27,6 +27,7 @@ async function generateSummary(productDir, customizerDir, extensions, output) {
   }
   await fs.mkdir(path.dirname(output), { recursive: true });
   await fs.writeFile(output, summary);
+  return summary;
 }
 
 module.exports = { generateSummary };


### PR DESCRIPTION
## Summary
- show generated summary inside the app
- expose summary result through preload
- display preview in renderer
- mention preview feature in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c631e31108323b049410435654246