### PR TITLE
Add tree view for selecting files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project is a cross-platform desktop application built with Electron, design
 
 - Select two root folders: one for the base Product codebase, one for the Customizer.
 - Filter and select files by extension (e.g., C#, JavaScript, SQL).
+- Display a tree view of files in the Customizer folder so you can choose which files to include.
 - Export selected files into a single summary document.
 - View the generated summary directly in the app before saving.
 - Generate a unified input file in Markdown or plain text format.

--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
       <input id="extensions" placeholder="Extensions e.g. .cs,.js" />
     </div>
     <div>
+      <button id="load-files">Load File Tree</button>
+    </div>
+    <div id="file-tree"></div>
+    <div>
       <button id="generate">Generate Summary</button>
     </div>
   <div id="status"></div>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const path = require('path');
-const { generateSummary } = require('./utils/fileUtils');
+const { generateSummary, listFiles } = require('./utils/fileUtils');
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -34,8 +34,14 @@ ipcMain.handle('select-folder', async () => {
   return filePaths[0];
 });
 
+ipcMain.handle('list-files', async (_event, opts) => {
+  const { dir, extensions } = opts;
+  const files = await listFiles(dir, extensions);
+  return files.map(f => path.relative(dir, f));
+});
+
 ipcMain.handle('generate-summary', async (_event, opts) => {
-  const { productDir, customizerDir, extensions, output } = opts;
-  const summary = await generateSummary(productDir, customizerDir, extensions, output);
+  const { productDir, customizerDir, extensions, output, selectedFiles } = opts;
+  const summary = await generateSummary(productDir, customizerDir, extensions, output, selectedFiles);
   return summary;
 });

--- a/preload.js
+++ b/preload.js
@@ -2,5 +2,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('api', {
   selectFolder: () => ipcRenderer.invoke('select-folder'),
+  listFiles: (opts) => ipcRenderer.invoke('list-files', opts),
   generateSummary: (opts) => ipcRenderer.invoke('generate-summary', opts)
 });

--- a/renderer.js
+++ b/renderer.js
@@ -1,6 +1,8 @@
 const productBtn = document.getElementById('product-btn');
 const customizerBtn = document.getElementById('customizer-btn');
 const generateBtn = document.getElementById('generate');
+const loadFilesBtn = document.getElementById('load-files');
+const fileTreeDiv = document.getElementById('file-tree');
 const productPathSpan = document.getElementById('product-path');
 const customizerPathSpan = document.getElementById('customizer-path');
 const statusDiv = document.getElementById('status');
@@ -8,6 +10,43 @@ const summaryPre = document.getElementById('summary');
 
 let productDir = null;
 let customizerDir = null;
+let fileList = [];
+
+function buildTree(paths) {
+  const root = {};
+  for (const p of paths) {
+    const parts = p.split(/[/\\]/);
+    let current = root;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (!current[part]) {
+        current[part] = { children: {}, path: parts.slice(0, i + 1).join('/') };
+      }
+      current = current[part].children;
+    }
+  }
+  return root;
+}
+
+function renderTree(node) {
+  const ul = document.createElement('ul');
+  for (const [name, info] of Object.entries(node)) {
+    const li = document.createElement('li');
+    if (Object.keys(info.children).length === 0) {
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.value = info.path;
+      checkbox.checked = true;
+      li.appendChild(checkbox);
+      li.append(' ' + name);
+    } else {
+      li.textContent = name;
+      li.appendChild(renderTree(info.children));
+    }
+    ul.appendChild(li);
+  }
+  return ul;
+}
 
 productBtn.addEventListener('click', async () => {
   const result = await window.api.selectFolder();
@@ -25,6 +64,18 @@ customizerBtn.addEventListener('click', async () => {
   }
 });
 
+loadFilesBtn.addEventListener('click', async () => {
+  if (!customizerDir) {
+    statusDiv.textContent = 'Select folders first.';
+    return;
+  }
+  const extensions = document.getElementById('extensions').value.split(',').map(e => e.trim()).filter(Boolean);
+  fileList = await window.api.listFiles({ dir: customizerDir, extensions });
+  const tree = buildTree(fileList);
+  fileTreeDiv.innerHTML = '';
+  fileTreeDiv.appendChild(renderTree(tree));
+});
+
 generateBtn.addEventListener('click', async () => {
   if (!productDir || !customizerDir) {
     statusDiv.textContent = 'Select both folders first.';
@@ -33,7 +84,8 @@ generateBtn.addEventListener('click', async () => {
   const extensions = document.getElementById('extensions').value.split(',').map(e => e.trim()).filter(Boolean);
   const output = 'output/summary.md';
   statusDiv.textContent = 'Generating...';
-  const summary = await window.api.generateSummary({ productDir, customizerDir, extensions, output });
+  const selected = Array.from(fileTreeDiv.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value);
+  const summary = await window.api.generateSummary({ productDir, customizerDir, extensions, output, selectedFiles: selected });
   statusDiv.textContent = 'Saved to ' + output;
   summaryPre.textContent = summary;
 });

--- a/utils/fileUtils.js
+++ b/utils/fileUtils.js
@@ -14,11 +14,10 @@ async function listFiles(dir, extensions, result = []) {
   return result;
 }
 
-async function generateSummary(productDir, customizerDir, extensions, output) {
-  const files = await listFiles(customizerDir, extensions);
+async function generateSummaryFromFiles(rootDir, files, output) {
   let summary = '';
-  for (const file of files) {
-    const relPath = path.relative(customizerDir, file);
+  for (const relPath of files) {
+    const file = path.join(rootDir, relPath);
     const content = await fs.readFile(file, 'utf8');
     summary += `## File: ${relPath}\n`;
     summary += '```\n';
@@ -30,4 +29,15 @@ async function generateSummary(productDir, customizerDir, extensions, output) {
   return summary;
 }
 
-module.exports = { generateSummary };
+async function generateSummary(productDir, customizerDir, extensions, output, selectedFiles = []) {
+  let files;
+  if (selectedFiles.length > 0) {
+    files = selectedFiles;
+  } else {
+    const all = await listFiles(customizerDir, extensions);
+    files = all.map(f => path.relative(customizerDir, f));
+  }
+  return generateSummaryFromFiles(customizerDir, files, output);
+}
+
+module.exports = { generateSummary, listFiles };


### PR DESCRIPTION
## Summary
- show a file tree of the Customizer folder
- allow selecting files to include in summary
- handle new list-files IPC call in main process
- document the new tree view feature

## Testing
- `node -c main.js`
- `node -c preload.js`
- `node -c renderer.js`
- `node -c utils/fileUtils.js`


------
https://chatgpt.com/codex/tasks/task_e_685c65858e348323b1c7373214ee36ed